### PR TITLE
feat: add configurable booking slots and paid reservation booking flow

### DIFF
--- a/backend/app/Http/Controllers/Api/BookingSlotSettingsController.php
+++ b/backend/app/Http/Controllers/Api/BookingSlotSettingsController.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\Admin\UpdateBookingSlotSettingsRequest;
+use App\Models\BookingSlot;
+use Carbon\Carbon;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
+
+class BookingSlotSettingsController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        Gate::authorize('manage-booking-slots');
+
+        return response()->json([
+            'success' => true,
+            'data' => [
+                'slots' => $this->formatSlots(BookingSlot::query()->ordered()->get()),
+            ],
+        ]);
+    }
+
+    public function update(UpdateBookingSlotSettingsRequest $request): JsonResponse
+    {
+        Gate::authorize('manage-booking-slots');
+
+        DB::transaction(function () use ($request): void {
+            $slots = collect($request->validated('slots'))
+                ->values()
+                ->map(function (array $slot, int $index): array {
+                    $now = now();
+
+                    return [
+                        'time' => $slot['time'],
+                        'capacity' => (int) $slot['capacity'],
+                        'is_active' => (bool) ($slot['is_active'] ?? true),
+                        'sort_order' => (int) ($slot['sort_order'] ?? ($index + 1)),
+                        'created_at' => $now,
+                        'updated_at' => $now,
+                    ];
+                });
+
+            BookingSlot::query()->upsert(
+                $slots->all(),
+                ['time'],
+                ['capacity', 'is_active', 'sort_order', 'updated_at']
+            );
+
+            BookingSlot::query()
+                ->whereNotIn('time', $slots->pluck('time')->all())
+                ->delete();
+        });
+
+        return response()->json([
+            'success' => true,
+            'data' => [
+                'slots' => $this->formatSlots(BookingSlot::query()->ordered()->get()),
+            ],
+            'message' => 'Booking slot settings updated successfully.',
+        ]);
+    }
+
+    /**
+     * @param  iterable<BookingSlot>  $slots
+     * @return array<int, array<string, mixed>>
+     */
+    private function formatSlots(iterable $slots): array
+    {
+        return collect($slots)
+            ->map(static fn (BookingSlot $slot): array => [
+                'id' => $slot->id,
+                'time' => $slot->time,
+                'label' => Carbon::createFromFormat('H:i', $slot->time)->format('g:i A'),
+                'capacity' => (int) $slot->capacity,
+                'is_active' => (bool) $slot->is_active,
+                'sort_order' => (int) $slot->sort_order,
+            ])
+            ->values()
+            ->all();
+    }
+}

--- a/backend/app/Http/Controllers/Api/CustomerBookingController.php
+++ b/backend/app/Http/Controllers/Api/CustomerBookingController.php
@@ -4,25 +4,105 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Api;
 
+use App\Enums\CustomerTransactionType;
 use App\Enums\JobOrderStatus;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\Customer\BookingAvailabilityRequest;
 use App\Http\Requests\Api\Customer\StoreCustomerBookingRequest;
+use App\Http\Requests\Api\Customer\StoreCustomerBookingWithPaymentRequest;
 use App\Http\Resources\JobOrderResource;
+use App\Models\BookingSlot;
 use App\Models\Customer;
+use App\Models\CustomerTransaction;
 use App\Models\JobOrder;
 use App\Models\JobOrderItem;
 use App\Models\ServiceCatalog;
+use App\Services\XenditService;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 class CustomerBookingController extends Controller
 {
+    /**
+     * Return booking slot availability for a specific date.
+     */
+    public function availability(BookingAvailabilityRequest $request): JsonResponse
+    {
+        $arrivalDate = $request->validated('arrival_date');
+
+        if (! Schema::hasTable('booking_slots')) {
+            return response()->json([
+                'success' => true,
+                'data' => [
+                    'arrival_date' => $arrivalDate,
+                    'slots' => [],
+                ],
+                'message' => 'Booking slots are not configured yet.',
+            ]);
+        }
+
+        $slotSettings = BookingSlot::query()->active()->ordered()->get(['time', 'capacity']);
+
+        if ($slotSettings->isEmpty()) {
+            return response()->json([
+                'success' => true,
+                'data' => [
+                    'arrival_date' => $arrivalDate,
+                    'slots' => [],
+                ],
+            ]);
+        }
+
+        $slotTimes = $slotSettings->pluck('time')->all();
+
+        $bookedByTime = $this->applyCapacityBlockingScope(
+            JobOrder::query()
+                ->whereDate('arrival_date', $arrivalDate)
+                ->whereIn('arrival_time', $slotTimes)
+        )
+            ->selectRaw('arrival_time, COUNT(*) as booked_count')
+            ->groupBy('arrival_time')
+            ->pluck('booked_count', 'arrival_time');
+
+        $slots = $slotSettings->map(function (BookingSlot $slot) use ($bookedByTime): array {
+            $bookedCount = (int) ($bookedByTime[$slot->time] ?? 0);
+            $slotsLeft = max($slot->capacity - $bookedCount, 0);
+
+            return [
+                'time' => $slot->time,
+                'label' => Carbon::createFromFormat('H:i', $slot->time)->format('g:i A'),
+                'status' => $slotsLeft > 0 ? 'available' : 'full',
+                'slots_left' => $slotsLeft,
+                'capacity' => (int) $slot->capacity,
+                'booked' => $bookedCount,
+            ];
+        })->values()->all();
+
+        return response()->json([
+            'success' => true,
+            'data' => [
+                'arrival_date' => $arrivalDate,
+                'slots' => $slots,
+            ],
+        ]);
+    }
+
     /**
      * Book a service for the authenticated customer.
      * Creates a job order in pending_approval status with the chosen service.
      */
     public function store(StoreCustomerBookingRequest $request): JsonResponse
     {
+        if (! Schema::hasTable('booking_slots')) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Booking slots are not configured yet. Please run database migrations.',
+            ], 503);
+        }
+
         $user = $request->user();
 
         $customer = Customer::where('email', $user->email)->first();
@@ -43,36 +123,47 @@ class CustomerBookingController extends Controller
             ], 422);
         }
 
+        $vehicleId = (int) $request->validated('vehicle_id');
+        $arrivalDate = $request->validated('arrival_date');
+        $arrivalTime = $request->validated('arrival_time');
+
+        if (! $customer->vehicles()->whereKey($vehicleId)->exists()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Selected vehicle does not belong to your account.',
+            ], 422);
+        }
+
+        $slotSetting = BookingSlot::query()
+            ->active()
+            ->where('time', $arrivalTime)
+            ->first();
+
+        if (! $slotSetting) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Selected arrival slot is unavailable.',
+            ], 422);
+        }
+
+        if (! $this->slotHasCapacity($arrivalDate, $slotSetting)) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Selected arrival slot is full. Please choose another time.',
+            ], 422);
+        }
+
+        $validated = $request->validated();
+
         try {
-            $jobOrder = DB::transaction(function () use ($customer, $service, $request) {
-                $jobOrder = JobOrder::create([
-                    'customer_id'  => $customer->id,
-                    'vehicle_id'   => $request->validated('vehicle_id'),
-                    'service_id'   => $service->id,
-                    'arrival_date' => $request->validated('arrival_date'),
-                    'arrival_time' => $request->validated('arrival_time'),
-                    'status'       => JobOrderStatus::PendingApproval,
-                    'service_fee'  => $service->price_fixed,
-                    'notes'        => $request->validated('notes'),
-                ]);
-
-                // Add service as a line item on the job order
-                JobOrderItem::create([
-                    'job_order_id' => $jobOrder->id,
-                    'item_type'    => 'service',
-                    'item_id'      => null,
-                    'description'  => $service->name,
-                    'quantity'     => 1,
-                    'unit_price'   => $service->price_fixed,
-                    'total_price'  => $service->price_fixed,
-                ]);
-
-                return $jobOrder->fresh(['customer', 'vehicle', 'service', 'items']);
+            $jobOrder = DB::transaction(function () use ($customer, $service, $validated) {
+                return $this->createPendingJobOrder($customer, $service, $validated)
+                    ->fresh(['customer', 'vehicle', 'service', 'items']);
             });
 
             return response()->json([
                 'success' => true,
-                'data'    => new JobOrderResource($jobOrder),
+                'data' => new JobOrderResource($jobOrder),
                 'message' => 'Booking submitted. Awaiting shop approval.',
             ], 201);
         } catch (\Exception $e) {
@@ -81,5 +172,190 @@ class CustomerBookingController extends Controller
                 'message' => 'Failed to create booking: '.$e->getMessage(),
             ], 500);
         }
+    }
+
+    /**
+     * Book a service with reservation fee payment.
+     * Creates a pending job order, creates a transaction, and returns a Xendit payment URL.
+     */
+    public function storeWithPayment(StoreCustomerBookingWithPaymentRequest $request, XenditService $xenditService): JsonResponse
+    {
+        if (! Schema::hasTable('booking_slots')) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Booking slots are not configured yet. Please run database migrations.',
+            ], 503);
+        }
+
+        $user = $request->user();
+
+        $customer = Customer::where('email', $user->email)->first();
+
+        if (! $customer) {
+            return response()->json([
+                'success' => false,
+                'message' => 'No customer record linked to this account.',
+            ], 404);
+        }
+
+        $service = ServiceCatalog::active()->find($request->validated('service_id'));
+
+        if (! $service) {
+            return response()->json([
+                'success' => false,
+                'message' => 'The selected service is unavailable.',
+            ], 422);
+        }
+
+        $vehicleId = (int) $request->validated('vehicle_id');
+        $arrivalDate = $request->validated('arrival_date');
+        $arrivalTime = $request->validated('arrival_time');
+
+        if (! $customer->vehicles()->whereKey($vehicleId)->exists()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Selected vehicle does not belong to your account.',
+            ], 422);
+        }
+
+        $slotSetting = BookingSlot::query()
+            ->active()
+            ->where('time', $arrivalTime)
+            ->first();
+
+        if (! $slotSetting) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Selected arrival slot is unavailable.',
+            ], 422);
+        }
+
+        if (! $this->slotHasCapacity($arrivalDate, $slotSetting)) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Selected arrival slot is full. Please choose another time.',
+            ], 422);
+        }
+
+        $validated = $request->validated();
+        $reservationFeeAmount = (float) config('inventory.booking_reservation_fee_amount', 200);
+
+        try {
+            $result = DB::transaction(function () use ($customer, $service, $validated, $reservationFeeAmount, $xenditService) {
+                $jobOrder = $this->createPendingJobOrder($customer, $service, $validated)
+                    ->fresh(['customer', 'vehicle', 'service', 'items']);
+
+                $transaction = CustomerTransaction::create([
+                    'customer_id' => $customer->id,
+                    'job_order_id' => $jobOrder->id,
+                    'type' => CustomerTransactionType::Invoice,
+                    'amount' => $reservationFeeAmount,
+                    'notes' => 'Reservation fee for booking '.$jobOrder->jo_number,
+                    'payment_method' => $validated['payment_method'],
+                ]);
+
+                $paymentUrl = $xenditService->createInvoice($transaction, $customer);
+
+                return [
+                    'job_order' => $jobOrder,
+                    'transaction_id' => $transaction->id,
+                    'payment_url' => $paymentUrl,
+                ];
+            });
+
+            return response()->json([
+                'success' => true,
+                'data' => [
+                    'job_order' => new JobOrderResource($result['job_order']),
+                    'transaction_id' => $result['transaction_id'],
+                    'reservation_fee_amount' => $reservationFeeAmount,
+                    'payment_url' => $result['payment_url'],
+                    'payment_method' => $validated['payment_method'],
+                ],
+                'message' => 'Booking created. Continue payment to secure your slot.',
+            ], 201);
+        } catch (\Exception $e) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Failed to initialize booking payment: '.$e->getMessage(),
+            ], 500);
+        }
+    }
+
+    private function slotHasCapacity(string $arrivalDate, BookingSlot $slotSetting): bool
+    {
+        $bookedCount = $this->applyCapacityBlockingScope(
+            JobOrder::query()
+                ->whereDate('arrival_date', $arrivalDate)
+                ->where('arrival_time', $slotSetting->time)
+        )->count();
+
+        return $bookedCount < $slotSetting->capacity;
+    }
+
+    /**
+     * Capacity is consumed by:
+     * - operational jobs (approved/in_progress/completed/settled), or
+     * - created/pending_approval jobs that already have a PAID reservation-fee invoice.
+     */
+    private function applyCapacityBlockingScope(Builder $query): Builder
+    {
+        return $query->where(function (Builder $blocking): void {
+            $blocking
+                ->whereIn('status', [
+                    JobOrderStatus::Approved->value,
+                    JobOrderStatus::InProgress->value,
+                    JobOrderStatus::Completed->value,
+                    JobOrderStatus::Settled->value,
+                ])
+                ->orWhere(function (Builder $awaitingPayment): void {
+                    $awaitingPayment
+                        ->whereIn('status', [
+                            JobOrderStatus::Created->value,
+                            JobOrderStatus::PendingApproval->value,
+                        ])
+                        ->whereExists(function ($transactionQuery): void {
+                            $transactionQuery
+                                ->select(DB::raw('1'))
+                                ->from('customer_transactions')
+                                ->whereColumn('customer_transactions.job_order_id', 'job_orders.id')
+                                ->whereIn('customer_transactions.type', [
+                                    CustomerTransactionType::Invoice->value,
+                                    CustomerTransactionType::ReservationFee->value,
+                                ])
+                                ->where('customer_transactions.xendit_status', 'PAID');
+                        });
+                });
+        });
+    }
+
+    /**
+     * @param  array<string, mixed>  $validated
+     */
+    private function createPendingJobOrder(Customer $customer, ServiceCatalog $service, array $validated): JobOrder
+    {
+        $jobOrder = JobOrder::create([
+            'customer_id' => $customer->id,
+            'vehicle_id' => $validated['vehicle_id'],
+            'service_id' => $service->id,
+            'arrival_date' => $validated['arrival_date'],
+            'arrival_time' => $validated['arrival_time'],
+            'status' => JobOrderStatus::PendingApproval,
+            'service_fee' => $service->price_fixed,
+            'notes' => $validated['notes'] ?? null,
+        ]);
+
+        // Keep the requested service in job order items so total-cost calculations stay consistent.
+        JobOrderItem::create([
+            'job_order_id' => $jobOrder->id,
+            'item_type' => 'service',
+            'item_id' => null,
+            'description' => $service->name,
+            'quantity' => 1,
+            'unit_price' => $service->price_fixed,
+            'total_price' => $service->price_fixed,
+        ]);
+
+        return $jobOrder;
     }
 }

--- a/backend/app/Http/Requests/Api/Admin/UpdateBookingSlotSettingsRequest.php
+++ b/backend/app/Http/Requests/Api/Admin/UpdateBookingSlotSettingsRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\Admin;
+
+use App\Enums\UserRole;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateBookingSlotSettingsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->role === UserRole::Admin;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'slots' => ['required', 'array', 'min:1'],
+            'slots.*.time' => ['required', 'date_format:H:i', 'distinct:strict'],
+            'slots.*.capacity' => ['required', 'integer', 'min:1', 'max:100'],
+            'slots.*.is_active' => ['sometimes', 'boolean'],
+            'slots.*.sort_order' => ['sometimes', 'integer', 'min:0', 'max:1000'],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/Api/Customer/BookingAvailabilityRequest.php
+++ b/backend/app/Http/Requests/Api/Customer/BookingAvailabilityRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\Customer;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class BookingAvailabilityRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'arrival_date' => ['required', 'date', 'date_format:Y-m-d', 'after_or_equal:today'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'arrival_date.required' => 'Please select an arrival date.',
+            'arrival_date.after_or_equal' => 'Arrival date cannot be in the past.',
+        ];
+    }
+}

--- a/backend/app/Http/Requests/Api/Customer/StoreCustomerBookingWithPaymentRequest.php
+++ b/backend/app/Http/Requests/Api/Customer/StoreCustomerBookingWithPaymentRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\Customer;
+
+use Illuminate\Validation\Rule;
+
+class StoreCustomerBookingWithPaymentRequest extends StoreCustomerBookingRequest
+{
+    public function rules(): array
+    {
+        return array_merge(parent::rules(), [
+            'payment_method' => ['required', 'string', Rule::in(['gcash', 'maya', 'card', 'bank'])],
+        ]);
+    }
+
+    public function messages(): array
+    {
+        return array_merge(parent::messages(), [
+            'payment_method.required' => 'Please select a payment method.',
+            'payment_method.in' => 'Selected payment method is invalid.',
+        ]);
+    }
+}

--- a/backend/app/Models/BookingSlot.php
+++ b/backend/app/Models/BookingSlot.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class BookingSlot extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'time',
+        'capacity',
+        'is_active',
+        'sort_order',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'capacity' => 'integer',
+            'is_active' => 'boolean',
+            'sort_order' => 'integer',
+        ];
+    }
+
+    public function scopeActive($query)
+    {
+        return $query->where('is_active', true);
+    }
+
+    public function scopeOrdered($query)
+    {
+        return $query->orderBy('sort_order')->orderBy('time');
+    }
+}

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -20,6 +20,7 @@ use App\Contracts\Services\JobOrderServiceInterface;
 use App\Contracts\Services\ReportServiceInterface;
 use App\Contracts\Services\ReservationServiceInterface;
 use App\Contracts\Services\VehicleServiceInterface;
+use App\Enums\UserRole;
 use App\Models\User;
 use App\Repositories\Eloquent\AlertRepository;
 use App\Repositories\Eloquent\ArchiveRepository;
@@ -110,6 +111,12 @@ class AppServiceProvider extends ServiceProvider
         Gate::define('approve-vehicles', fn (User $user): bool => $this->canAccessSensitiveEndpoints($user));
         Gate::define('view-audit-logs', fn (User $user): bool => $this->canAccessSensitiveEndpoints($user));
         Gate::define('link-transactions', fn (User $user): bool => $this->canAccessSensitiveEndpoints($user));
+        Gate::define('manage-booking-slots', fn (User $user): bool => $this->canManageBookingSlots($user));
+    }
+
+    private function canManageBookingSlots(User $user): bool
+    {
+        return $this->canAccessSensitiveEndpoints($user) && $user->role === UserRole::Admin;
     }
 
     private function canAccessSensitiveEndpoints(User $user): bool

--- a/backend/app/Services/XenditService.php
+++ b/backend/app/Services/XenditService.php
@@ -19,8 +19,10 @@ class XenditService
 
     public function __construct()
     {
-        Configuration::setXenditKey((string) config('xendit.secret_key'));
-        $this->invoiceApi = new InvoiceApi;
+        $this->withoutDeprecationWarnings(function (): void {
+            Configuration::setXenditKey((string) config('xendit.secret_key'));
+            $this->invoiceApi = new InvoiceApi;
+        });
     }
 
     /**
@@ -47,8 +49,11 @@ class XenditService
         ];
 
         try {
-            $createRequest = new CreateInvoiceRequest($requestData);
-            $response = $this->invoiceApi->createInvoice($createRequest);
+            $response = $this->withoutDeprecationWarnings(function () use ($requestData) {
+                $createRequest = new CreateInvoiceRequest($requestData);
+
+                return $this->invoiceApi->createInvoice($createRequest);
+            });
         } catch (\Throwable $e) {
             throw new RuntimeException('Xendit invoice creation failed: '.$e->getMessage(), 0, $e);
         }
@@ -114,8 +119,11 @@ class XenditService
         ];
 
         try {
-            $createRequest = new CreateInvoiceRequest($requestData);
-            $response = $this->invoiceApi->createInvoice($createRequest);
+            $response = $this->withoutDeprecationWarnings(function () use ($requestData) {
+                $createRequest = new CreateInvoiceRequest($requestData);
+
+                return $this->invoiceApi->createInvoice($createRequest);
+            });
         } catch (\Throwable $e) {
             $transaction->delete();
             throw new RuntimeException('Xendit invoice creation failed: '.$e->getMessage(), 0, $e);
@@ -134,5 +142,26 @@ class XenditService
         $reservation->update(['fee_transaction_id' => $transaction->id]);
 
         return $paymentUrl;
+    }
+
+    /**
+     * Wrap vendor calls so PHP 8.4 deprecation notices in third-party SDKs
+     * do not pollute API responses while preserving normal warnings elsewhere.
+     *
+     * @template T
+     *
+     * @param  callable():T  $callback
+     * @return T
+     */
+    private function withoutDeprecationWarnings(callable $callback): mixed
+    {
+        $previous = error_reporting();
+        error_reporting($previous & ~E_DEPRECATED & ~E_USER_DEPRECATED);
+
+        try {
+            return $callback();
+        } finally {
+            error_reporting($previous);
+        }
     }
 }

--- a/backend/config/inventory.php
+++ b/backend/config/inventory.php
@@ -46,6 +46,9 @@ return [
     // Reservation fee as a percentage of the reserved parts' total value (quantity × unit_price)
     'reservation_fee_percentage' => (int) env('RESERVATION_FEE_PERCENTAGE', 20),
 
+    // Fixed reservation fee (PHP) for customer service bookings paid online.
+    'booking_reservation_fee_amount' => (float) env('BOOKING_RESERVATION_FEE_AMOUNT', 200),
+
     /*
     |--------------------------------------------------------------------------
     | Pagination Settings

--- a/backend/database/migrations/2026_04_10_130000_create_booking_slots_table.php
+++ b/backend/database/migrations/2026_04_10_130000_create_booking_slots_table.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('booking_slots', function (Blueprint $table) {
+            $table->id();
+            $table->string('time', 5)->unique(); // HH:MM in 24-hour format
+            $table->unsignedSmallInteger('capacity')->default(3);
+            $table->boolean('is_active')->default(true);
+            $table->unsignedSmallInteger('sort_order')->default(0);
+            $table->timestamps();
+
+            $table->index(['is_active', 'sort_order']);
+        });
+
+        $now = now();
+
+        DB::table('booking_slots')->insert([
+            ['time' => '10:00', 'capacity' => 3, 'is_active' => true, 'sort_order' => 1, 'created_at' => $now, 'updated_at' => $now],
+            ['time' => '11:00', 'capacity' => 3, 'is_active' => true, 'sort_order' => 2, 'created_at' => $now, 'updated_at' => $now],
+            ['time' => '12:00', 'capacity' => 3, 'is_active' => true, 'sort_order' => 3, 'created_at' => $now, 'updated_at' => $now],
+            ['time' => '12:30', 'capacity' => 3, 'is_active' => true, 'sort_order' => 4, 'created_at' => $now, 'updated_at' => $now],
+        ]);
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('booking_slots');
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -2,10 +2,11 @@
 
 declare(strict_types=1);
 
-use App\Http\Controllers\Api\CustomerBookingController;
 use App\Http\Controllers\Api\AlertController;
 use App\Http\Controllers\Api\ArchiveController;
 use App\Http\Controllers\Api\BayController;
+use App\Http\Controllers\Api\BookingSlotSettingsController;
+use App\Http\Controllers\Api\CustomerBookingController;
 use App\Http\Controllers\Api\CustomerController;
 use App\Http\Controllers\Api\FrontDeskAccountController;
 use App\Http\Controllers\Api\HealthController;
@@ -233,6 +234,11 @@ Route::prefix('v1')->name('api.v1.')->middleware(['auth:sanctum', 'throttle:api'
         Route::delete('/{id}', [FrontDeskAccountController::class, 'destroy'])->name('destroy');
     });
 
+    Route::prefix('admin/booking-slots')->name('admin.booking-slots.')->group(function () {
+        Route::get('/', [BookingSlotSettingsController::class, 'index'])->name('index');
+        Route::put('/', [BookingSlotSettingsController::class, 'update'])->name('update');
+    });
+
     /*
     |--------------------------------------------------------------------------
     | Payment Routes
@@ -260,7 +266,9 @@ Route::prefix('v1')->name('api.v1.')->middleware(['auth:sanctum', 'throttle:api'
     */
 
     Route::prefix('customer')->name('customer.')->group(function () {
+        Route::get('/availability', [CustomerBookingController::class, 'availability'])->name('availability');
         Route::post('/book', [CustomerBookingController::class, 'store'])->name('book');
+        Route::post('/book-with-payment', [CustomerBookingController::class, 'storeWithPayment'])->name('book-with-payment');
     });
 });
 

--- a/backend/tests/Feature/Api/BookingSlotSettingsApiTest.php
+++ b/backend/tests/Feature/Api/BookingSlotSettingsApiTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BookingSlotSettingsApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_index_requires_authentication(): void
+    {
+        $this->getJson('/api/v1/admin/booking-slots')
+            ->assertStatus(401);
+    }
+
+    public function test_index_forbids_non_admin_users(): void
+    {
+        $user = User::factory()->create(['role' => 'customer']);
+
+        $this->actingAs($user)
+            ->getJson('/api/v1/admin/booking-slots')
+            ->assertStatus(403);
+    }
+
+    public function test_index_returns_booking_slot_settings_for_admin(): void
+    {
+        $admin = User::factory()->create(['role' => 'admin']);
+
+        $response = $this->actingAs($admin)
+            ->getJson('/api/v1/admin/booking-slots');
+
+        $response->assertStatus(200)
+            ->assertJsonPath('success', true)
+            ->assertJsonStructure([
+                'success',
+                'data' => [
+                    'slots' => [
+                        '*' => ['id', 'time', 'label', 'capacity', 'is_active', 'sort_order'],
+                    ],
+                ],
+            ]);
+    }
+
+    public function test_update_replaces_slot_settings_for_admin(): void
+    {
+        $admin = User::factory()->create(['role' => 'admin']);
+
+        $payload = [
+            'slots' => [
+                ['time' => '09:30', 'capacity' => 2, 'is_active' => true, 'sort_order' => 1],
+                ['time' => '10:15', 'capacity' => 1, 'is_active' => false, 'sort_order' => 2],
+            ],
+        ];
+
+        $response = $this->actingAs($admin)
+            ->putJson('/api/v1/admin/booking-slots', $payload);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.slots.0.time', '09:30')
+            ->assertJsonPath('data.slots.0.capacity', 2)
+            ->assertJsonPath('data.slots.1.time', '10:15')
+            ->assertJsonPath('data.slots.1.is_active', false);
+
+        $this->assertDatabaseHas('booking_slots', [
+            'time' => '09:30',
+            'capacity' => 2,
+            'is_active' => 1,
+        ]);
+
+        $this->assertDatabaseHas('booking_slots', [
+            'time' => '10:15',
+            'capacity' => 1,
+            'is_active' => 0,
+        ]);
+
+        $this->assertDatabaseMissing('booking_slots', [
+            'time' => '12:30',
+        ]);
+    }
+}

--- a/backend/tests/Feature/Api/CustomerBookingApiTest.php
+++ b/backend/tests/Feature/Api/CustomerBookingApiTest.php
@@ -1,0 +1,317 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\BookingSlot;
+use App\Models\Customer;
+use App\Models\CustomerTransaction;
+use App\Models\JobOrder;
+use App\Models\ServiceCatalog;
+use App\Models\User;
+use App\Models\Vehicle;
+use App\Services\XenditService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CustomerBookingApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Customer $customer;
+
+    private Vehicle $vehicle;
+
+    private ServiceCatalog $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->customer = Customer::factory()->create([
+            'email' => $this->user->email,
+        ]);
+        $this->vehicle = Vehicle::factory()->create([
+            'customer_id' => $this->customer->id,
+        ]);
+        $this->service = ServiceCatalog::create([
+            'name' => 'Oil Change',
+            'description' => 'Synthetic oil change service',
+            'price_label' => 'P1200',
+            'price_fixed' => 1200,
+            'duration' => '30 mins',
+            'estimated_duration' => '45-60 mins',
+            'category' => 'maintenance',
+            'features' => ['Oil refill'],
+            'includes' => ['Oil filter replacement'],
+            'rating' => 4.5,
+            'rating_count' => 10,
+            'recommended' => false,
+            'is_active' => true,
+        ]);
+
+        BookingSlot::query()->updateOrCreate(
+            ['time' => '10:00'],
+            ['capacity' => 3, 'is_active' => true, 'sort_order' => 1]
+        );
+        BookingSlot::query()->updateOrCreate(
+            ['time' => '11:00'],
+            ['capacity' => 3, 'is_active' => true, 'sort_order' => 2]
+        );
+    }
+
+    public function test_availability_requires_authentication(): void
+    {
+        $date = now()->addDay()->toDateString();
+
+        $this->getJson('/api/v1/customer/availability?arrival_date='.$date)
+            ->assertStatus(401);
+    }
+
+    public function test_availability_returns_slots_with_database_counts(): void
+    {
+        $date = now()->addDay()->toDateString();
+
+        $paidPendingJob = JobOrder::factory()->create([
+            'customer_id' => $this->customer->id,
+            'vehicle_id' => $this->vehicle->id,
+            'status' => 'pending_approval',
+            'arrival_date' => $date,
+            'arrival_time' => '10:00',
+        ]);
+
+        CustomerTransaction::create([
+            'customer_id' => $this->customer->id,
+            'job_order_id' => $paidPendingJob->id,
+            'type' => 'invoice',
+            'amount' => 200,
+            'xendit_status' => 'PAID',
+            'paid_at' => now(),
+        ]);
+
+        JobOrder::factory()->create([
+            'customer_id' => $this->customer->id,
+            'vehicle_id' => $this->vehicle->id,
+            'status' => 'approved',
+            'arrival_date' => $date,
+            'arrival_time' => '10:00',
+        ]);
+        JobOrder::factory()->create([
+            'customer_id' => $this->customer->id,
+            'vehicle_id' => $this->vehicle->id,
+            'status' => 'pending_approval',
+            'arrival_date' => $date,
+            'arrival_time' => '10:00',
+        ]);
+        JobOrder::factory()->create([
+            'customer_id' => $this->customer->id,
+            'vehicle_id' => $this->vehicle->id,
+            'status' => 'cancelled',
+            'arrival_date' => $date,
+            'arrival_time' => '11:00',
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->getJson('/api/v1/customer/availability?arrival_date='.$date);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.arrival_date', $date);
+
+        $slots = collect($response->json('data.slots'))->keyBy('time');
+
+        $this->assertEquals('available', $slots->get('10:00')['status']);
+        $this->assertEquals(1, $slots->get('10:00')['slots_left']);
+        $this->assertEquals(3, $slots->get('10:00')['capacity']);
+        $this->assertEquals(2, $slots->get('10:00')['booked']);
+
+        $this->assertEquals('available', $slots->get('11:00')['status']);
+        $this->assertEquals(3, $slots->get('11:00')['slots_left']);
+        $this->assertEquals(0, $slots->get('11:00')['booked']);
+    }
+
+    public function test_store_rejects_vehicle_not_owned_by_customer(): void
+    {
+        $otherCustomerVehicle = Vehicle::factory()->create();
+
+        $payload = [
+            'vehicle_id' => $otherCustomerVehicle->id,
+            'service_id' => $this->service->id,
+            'arrival_date' => now()->addDay()->toDateString(),
+            'arrival_time' => '10:00',
+        ];
+
+        $this->actingAs($this->user)
+            ->postJson('/api/v1/customer/book', $payload)
+            ->assertStatus(422)
+            ->assertJsonPath('message', 'Selected vehicle does not belong to your account.');
+    }
+
+    public function test_store_rejects_full_slot(): void
+    {
+        BookingSlot::query()->where('time', '10:00')->update(['capacity' => 1]);
+        $date = now()->addDay()->toDateString();
+
+        $paidPendingJob = JobOrder::factory()->create([
+            'customer_id' => $this->customer->id,
+            'vehicle_id' => $this->vehicle->id,
+            'status' => 'pending_approval',
+            'arrival_date' => $date,
+            'arrival_time' => '10:00',
+        ]);
+
+        CustomerTransaction::create([
+            'customer_id' => $this->customer->id,
+            'job_order_id' => $paidPendingJob->id,
+            'type' => 'invoice',
+            'amount' => 200,
+            'xendit_status' => 'PAID',
+            'paid_at' => now(),
+        ]);
+
+        $payload = [
+            'vehicle_id' => $this->vehicle->id,
+            'service_id' => $this->service->id,
+            'arrival_date' => $date,
+            'arrival_time' => '10:00',
+        ];
+
+        $this->actingAs($this->user)
+            ->postJson('/api/v1/customer/book', $payload)
+            ->assertStatus(422)
+            ->assertJsonPath('message', 'Selected arrival slot is full. Please choose another time.');
+    }
+
+    public function test_store_allows_booking_when_existing_pending_booking_is_unpaid(): void
+    {
+        BookingSlot::query()->where('time', '10:00')->update(['capacity' => 1]);
+        $date = now()->addDay()->toDateString();
+
+        JobOrder::factory()->create([
+            'customer_id' => $this->customer->id,
+            'vehicle_id' => $this->vehicle->id,
+            'status' => 'pending_approval',
+            'arrival_date' => $date,
+            'arrival_time' => '10:00',
+        ]);
+
+        $payload = [
+            'vehicle_id' => $this->vehicle->id,
+            'service_id' => $this->service->id,
+            'arrival_date' => $date,
+            'arrival_time' => '10:00',
+        ];
+
+        $this->actingAs($this->user)
+            ->postJson('/api/v1/customer/book', $payload)
+            ->assertStatus(201)
+            ->assertJsonPath('success', true);
+    }
+
+    public function test_store_creates_booking_when_slot_is_available(): void
+    {
+        BookingSlot::query()->where('time', '10:00')->update(['capacity' => 2]);
+        $date = now()->addDay()->toDateString();
+
+        $payload = [
+            'vehicle_id' => $this->vehicle->id,
+            'service_id' => $this->service->id,
+            'arrival_date' => $date,
+            'arrival_time' => '10:00',
+            'notes' => 'Please prioritize if possible.',
+        ];
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/api/v1/customer/book', $payload);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.status', 'pending_approval')
+            ->assertJsonPath('data.arrival_date', $date)
+            ->assertJsonPath('data.arrival_time', '10:00');
+
+        $this->assertDatabaseHas('job_orders', [
+            'customer_id' => $this->customer->id,
+            'vehicle_id' => $this->vehicle->id,
+            'service_id' => $this->service->id,
+            'status' => 'pending_approval',
+            'arrival_date' => $date,
+            'arrival_time' => '10:00',
+        ]);
+    }
+
+    public function test_store_with_payment_creates_booking_transaction_and_payment_url(): void
+    {
+        BookingSlot::query()->where('time', '10:00')->update(['capacity' => 2]);
+        $date = now()->addDay()->toDateString();
+
+        $this->mock(XenditService::class, function ($mock): void {
+            $mock->shouldReceive('createInvoice')
+                ->once()
+                ->andReturnUsing(function (CustomerTransaction $transaction): string {
+                    $url = 'https://checkout.xendit.co/inv-test-booking-fee';
+
+                    $transaction->update([
+                        'payment_url' => $url,
+                        'xendit_status' => 'PENDING',
+                    ]);
+
+                    return $url;
+                });
+        });
+
+        $payload = [
+            'vehicle_id' => $this->vehicle->id,
+            'service_id' => $this->service->id,
+            'arrival_date' => $date,
+            'arrival_time' => '10:00',
+            'payment_method' => 'gcash',
+        ];
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/api/v1/customer/book-with-payment', $payload);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.job_order.status', 'pending_approval')
+            ->assertJsonPath('data.payment_url', 'https://checkout.xendit.co/inv-test-booking-fee')
+            ->assertJsonPath('data.payment_method', 'gcash');
+
+        $jobOrder = JobOrder::query()->latest('id')->first();
+
+        $this->assertNotNull($jobOrder);
+
+        $this->assertDatabaseHas('customer_transactions', [
+            'customer_id' => $this->customer->id,
+            'job_order_id' => $jobOrder?->id,
+            'type' => 'invoice',
+            'payment_method' => 'gcash',
+            'payment_url' => 'https://checkout.xendit.co/inv-test-booking-fee',
+            'xendit_status' => 'PENDING',
+        ]);
+
+        $transactionId = $response->json('data.transaction_id');
+        $this->assertIsInt($transactionId);
+        $this->assertTrue(CustomerTransaction::query()->whereKey($transactionId)->exists());
+    }
+
+    public function test_store_with_payment_rejects_invalid_payment_method(): void
+    {
+        $payload = [
+            'vehicle_id' => $this->vehicle->id,
+            'service_id' => $this->service->id,
+            'arrival_date' => now()->addDay()->toDateString(),
+            'arrival_time' => '10:00',
+            'payment_method' => 'cash',
+        ];
+
+        $this->actingAs($this->user)
+            ->postJson('/api/v1/customer/book-with-payment', $payload)
+            ->assertStatus(422)
+            ->assertJsonPath('message', 'Selected payment method is invalid.');
+    }
+}

--- a/frontend/src/pages/customer/services.tsx
+++ b/frontend/src/pages/customer/services.tsx
@@ -2,9 +2,9 @@ import CustomerLayout from '@/components/layout/customer-layout';
 import { useCustomerProfile } from '@/hooks/useCustomerProfile';
 import { useServiceCatalog } from '@/hooks/useServiceCatalog';
 import { customerService } from '@/services/customerService';
-import { JobOrder, ServiceCatalogItem, Vehicle } from '@/types/customer';
+import { BookingTimeSlot, JobOrder, ServiceCatalogItem, Vehicle } from '@/types/customer';
 import { AlertTriangle, ArrowRight, Check, ChevronDown, ChevronLeft, ChevronRight, Clock, Loader2, Star, Users, X } from 'lucide-react';
-import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 // ── types ─────────────────────────────────────────────────────────────────────
 type Category = 'Maintenance' | 'Cleaning' | 'Repair';
@@ -15,12 +15,11 @@ const categoryMap: Record<string, Category> = {
     repair: 'Repair',
 };
 
-// ── static data (time slots remain hardcoded) ─────────────────────────────────
-const TIME_SLOTS = [
-    { time: '10:00 AM', status: 'available' as const, slotsLeft: 1 },
-    { time: '11:00 AM', status: 'full' as const, slotsLeft: 0 },
-    { time: '12:00 PM', status: 'available' as const, slotsLeft: 2 },
-    { time: '12:30 PM', status: 'available' as const, slotsLeft: 4 },
+const FALLBACK_TIME_SLOTS: BookingTimeSlot[] = [
+    { time: '10:00', label: '10:00 AM', status: 'available', slots_left: 1, capacity: 1, booked: 0 },
+    { time: '11:00', label: '11:00 AM', status: 'full', slots_left: 0, capacity: 1, booked: 1 },
+    { time: '12:00', label: '12:00 PM', status: 'available', slots_left: 2, capacity: 2, booked: 0 },
+    { time: '12:30', label: '12:30 PM', status: 'available', slots_left: 4, capacity: 4, booked: 0 },
 ];
 
 const CATEGORIES: Category[] = ['Maintenance', 'Cleaning', 'Repair'];
@@ -44,14 +43,18 @@ function Stars({ rating, count }: { rating: number; count?: number }) {
     );
 }
 
-function parseTime(timeStr: string): { h: number; m: number } {
-    const [timePart, meridiem] = timeStr.split(' ');
-    const parts = timePart.split(':').map(Number);
-    let h = parts[0];
-    const m = parts[1];
-    if (meridiem === 'PM' && h !== 12) h += 12;
-    if (meridiem === 'AM' && h === 12) h = 0;
+function parseTime24h(timeStr: string): { h: number; m: number } {
+    const [hRaw, mRaw] = timeStr.split(':');
+    const h = Number(hRaw);
+    const m = Number(mRaw);
     return { h, m };
+}
+
+function formatDateYmd(date: Date): string {
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, '0');
+    const d = String(date.getDate()).padStart(2, '0');
+    return `${y}-${m}-${d}`;
 }
 
 function fmtTime(d: Date) {
@@ -214,14 +217,14 @@ function CalendarDropdown({
 // ── Modals ───────────────────────────────────────────────────────────────────
 type ModalStep = 'confirm' | 'secure' | 'payment' | 'verify-phone' | 'verify-otp' | 'success' | 'reserved' | null;
 type SecureOption = 'reservation' | 'no-payment';
-type PayMethod = 'gcash' | 'maya' | 'card' | 'bank';
+
+const DEFAULT_PAYMENT_METHOD = 'gcash' as const;
 
 export default function CustomerServices() {
     const [activeCategory, setActiveCategory] = useState<Category>('Maintenance');
     const [selectedId, setSelectedId] = useState(2);
     const [modalStep, setModalStep] = useState<ModalStep>(null);
     const [secureOption, setSecureOption] = useState<SecureOption>('reservation');
-    const [payMethod, setPayMethod] = useState<PayMethod>('gcash');
     const [phone, setPhone] = useState('');
     const [otp, setOtp] = useState(['', '', '', '', '', '']);
     const [otpCountdown, setOtpCountdown] = useState(0);
@@ -231,7 +234,10 @@ export default function CustomerServices() {
         d.setHours(0, 0, 0, 0);
         return d;
     });
+    const [timeSlots, setTimeSlots] = useState<BookingTimeSlot[]>(FALLBACK_TIME_SLOTS);
     const [selectedTimeIdx, setSelectedTimeIdx] = useState(0);
+    const [slotsLoading, setSlotsLoading] = useState(false);
+    const [slotsError, setSlotsError] = useState<string | null>(null);
     const [calendarOpen, setCalendarOpen] = useState(false);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [bookingError, setBookingError] = useState<string | null>(null);
@@ -244,6 +250,48 @@ export default function CustomerServices() {
 
     const vehicles: Vehicle[] = customer?.vehicles ?? [];
     const selectedVehicle = vehicles.find((v) => v.id === selectedVehicleId) ?? vehicles[0] ?? null;
+    const arrivalDateYmd = useMemo(() => formatDateYmd(selectedDate), [selectedDate]);
+
+    // Fetch arrival slot availability from backend whenever the selected date changes.
+    useEffect(() => {
+        let cancelled = false;
+
+        const fetchAvailability = async () => {
+            setSlotsLoading(true);
+            setSlotsError(null);
+
+            try {
+                const response = await customerService.getBookingAvailability(arrivalDateYmd);
+                const fetchedSlots = response.data?.slots ?? [];
+                const nextSlots = fetchedSlots.length > 0 ? fetchedSlots : FALLBACK_TIME_SLOTS;
+
+                if (cancelled) return;
+
+                setTimeSlots(nextSlots);
+                setSelectedTimeIdx((prev) => {
+                    if (nextSlots.length === 0) return 0;
+                    if (prev < nextSlots.length && nextSlots[prev].status !== 'full') return prev;
+
+                    const firstAvailableIdx = nextSlots.findIndex((s) => s.status !== 'full');
+                    return firstAvailableIdx >= 0 ? firstAvailableIdx : 0;
+                });
+            } catch (err) {
+                if (cancelled) return;
+
+                setSlotsError(err instanceof Error ? err.message : 'Failed to load arrival times.');
+                setTimeSlots(FALLBACK_TIME_SLOTS);
+                setSelectedTimeIdx((prev) => Math.min(prev, FALLBACK_TIME_SLOTS.length - 1));
+            } finally {
+                if (!cancelled) setSlotsLoading(false);
+            }
+        };
+
+        fetchAvailability();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [arrivalDateYmd]);
 
     // Auto-select first vehicle when profile loads
     useEffect(() => {
@@ -281,14 +329,18 @@ export default function CustomerServices() {
     const fmtCountdown = `00:${String(otpCountdown).padStart(2, '0')}`;
 
     async function submitBooking() {
-        if (!selectedService || !selectedVehicle) return;
+        if (!selectedService || !selectedVehicle || !slot) return;
+
+        if (slot.status === 'full') {
+            setBookingError('Selected arrival slot is full. Please choose another time.');
+            return;
+        }
+
         setIsSubmitting(true);
         setBookingError(null);
 
-        // Format arrival time as HH:MM (24h)
-        const { h, m: slotMin } = parseTime(slot.time);
-        const arrivalTime = `${String(h).padStart(2, '0')}:${String(slotMin).padStart(2, '0')}`;
-        const arrivalDate = selectedDate.toISOString().split('T')[0]; // Y-m-d
+        const arrivalTime = slot.time;
+        const arrivalDate = arrivalDateYmd;
 
         try {
             const response = await customerService.createBooking({
@@ -298,13 +350,48 @@ export default function CustomerServices() {
                 arrival_time: arrivalTime,
             });
             setConfirmedJO(response.data);
-            if (secureOption === 'no-payment') {
-                setModalStep('reserved');
-            } else {
-                setModalStep('success');
-            }
+            setModalStep('reserved');
         } catch (err) {
             const msg = err instanceof Error ? err.message : 'Booking failed. Please try again.';
+            setBookingError(msg);
+        } finally {
+            setIsSubmitting(false);
+        }
+    }
+
+    async function submitBookingWithPayment() {
+        if (!selectedService || !selectedVehicle || !slot) return;
+
+        if (slot.status === 'full') {
+            setBookingError('Selected arrival slot is full. Please choose another time.');
+            return;
+        }
+
+        setIsSubmitting(true);
+        setBookingError(null);
+
+        const arrivalTime = slot.time;
+        const arrivalDate = arrivalDateYmd;
+
+        try {
+            const response = await customerService.createBookingWithPayment({
+                vehicle_id: selectedVehicle.id,
+                service_id: selectedService.id,
+                arrival_date: arrivalDate,
+                arrival_time: arrivalTime,
+                payment_method: DEFAULT_PAYMENT_METHOD,
+            });
+
+            setConfirmedJO(response.data.job_order);
+
+            if (!response.data.payment_url) {
+                setBookingError('Payment link unavailable. Please try again.');
+                return;
+            }
+
+            window.location.href = response.data.payment_url;
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : 'Failed to initialize payment. Please try again.';
             setBookingError(msg);
         } finally {
             setIsSubmitting(false);
@@ -334,10 +421,12 @@ export default function CustomerServices() {
     }, []);
 
     // Booking summary times
-    const slot = TIME_SLOTS[selectedTimeIdx];
-    const arrivalStr = `${selectedDate.toLocaleDateString('en-US', { weekday: 'short' })} ${selectedDate.toLocaleDateString('en-US', { month: 'short' })} ${selectedDate.getDate()}, ${slot.time}`;
+    const slot = timeSlots[selectedTimeIdx] ?? timeSlots[0] ?? null;
+    const slotLabel = slot?.label ?? 'N/A';
+    const slotTime = slot?.time ?? FALLBACK_TIME_SLOTS[0].time;
+    const arrivalStr = `${selectedDate.toLocaleDateString('en-US', { weekday: 'short' })} ${selectedDate.toLocaleDateString('en-US', { month: 'short' })} ${selectedDate.getDate()}, ${slotLabel}`;
 
-    const { h, m } = parseTime(slot.time);
+    const { h, m } = parseTime24h(slotTime);
     const estStart = new Date();
     estStart.setHours(h, m + 15, 0, 0);
     const durNums = (selectedService?.estimated_duration ?? '30').match(/\d+/g) ?? ['30'];
@@ -570,14 +659,21 @@ export default function CustomerServices() {
                     {/* Select arrival time */}
                     <div>
                         <p className="mb-2 text-xs font-semibold text-foreground">Select arrival time</p>
+                        {slotsLoading && (
+                            <div className="mb-1 flex items-center gap-1.5 text-[11px] text-muted-foreground">
+                                <Loader2 className="h-3 w-3 animate-spin" />
+                                <span>Loading available time slots...</span>
+                            </div>
+                        )}
+                        {slotsError && !slotsLoading && <p className="mb-1 text-[11px] text-amber-400">{slotsError}</p>}
                         <div className="flex flex-col gap-1.5">
-                            {TIME_SLOTS.map((s, idx) => {
+                            {timeSlots.map((s, idx) => {
                                 const isSelected = selectedTimeIdx === idx && s.status !== 'full';
                                 const isFull = s.status === 'full';
                                 return (
                                     <button
                                         key={s.time}
-                                        disabled={isFull}
+                                        disabled={isFull || slotsLoading}
                                         onClick={() => !isFull && setSelectedTimeIdx(idx)}
                                         className={`flex items-center justify-between rounded-lg px-3 py-2 text-xs transition-colors ${
                                             isSelected
@@ -587,17 +683,22 @@ export default function CustomerServices() {
                                                   : 'border border-[#2a2a2e] text-foreground hover:border-[#d4af37]/50'
                                         }`}
                                     >
-                                        <span>{s.time}</span>
+                                        <span>{s.label}</span>
                                         <span className={isSelected ? 'text-black/70' : 'text-muted-foreground'}>
                                             {isFull
                                                 ? 'Full'
                                                 : isSelected
-                                                  ? `${s.slotsLeft} slot${s.slotsLeft !== 1 ? 's' : ''} left`
-                                                  : `${s.slotsLeft} Slot${s.slotsLeft !== 1 ? 's' : ''} Left`}
+                                                  ? `${s.slots_left} slot${s.slots_left !== 1 ? 's' : ''} left`
+                                                  : `${s.slots_left} Slot${s.slots_left !== 1 ? 's' : ''} Left`}
                                         </span>
                                     </button>
                                 );
                             })}
+                            {!slotsLoading && timeSlots.length === 0 && (
+                                <p className="rounded-lg border border-[#2a2a2e] px-3 py-2 text-xs text-muted-foreground">
+                                    No arrival slots available for this date.
+                                </p>
+                            )}
                         </div>
                     </div>
 
@@ -939,66 +1040,7 @@ export default function CustomerServices() {
                                 <p className="mt-0.5 text-xs text-muted-foreground">This amount will be deducted from your total bill</p>
                             </div>
 
-                            <div className="h-px bg-[#2a2a2e]" />
-
-                            {/* Payment methods */}
-                            <div className="flex flex-col gap-2">
-                                {(
-                                    [
-                                        {
-                                            key: 'gcash' as PayMethod,
-                                            label: 'GCash',
-                                            icon: <img src="/images/gcash.png" alt="GCash" className="h-4 w-auto max-w-5 object-contain" />,
-                                        },
-                                        {
-                                            key: 'maya' as PayMethod,
-                                            label: 'Maya',
-                                            icon: <img src="/images/Maya.png" alt="Maya" className="h-3 w-auto max-w-11 object-contain" />,
-                                        },
-                                        {
-                                            key: 'card' as PayMethod,
-                                            label: 'Credit/Debit Card',
-                                            icon: (
-                                                <img src="/images/debit.png" alt="Credit/Debit Card" className="h-6 w-auto max-w-10 object-contain" />
-                                            ),
-                                        },
-                                        {
-                                            key: 'bank' as PayMethod,
-                                            label: 'Bank Transfer',
-                                            icon: (
-                                                <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" className="h-5 w-5">
-                                                    <path d="M16 4L3 11h26L16 4z" fill="#9ca3af" />
-                                                    <rect x="5" y="14" width="3.5" height="9" rx="0.5" fill="#9ca3af" />
-                                                    <rect x="14.25" y="14" width="3.5" height="9" rx="0.5" fill="#9ca3af" />
-                                                    <rect x="23.5" y="14" width="3.5" height="9" rx="0.5" fill="#9ca3af" />
-                                                    <rect x="3" y="24" width="26" height="2.5" rx="1" fill="#9ca3af" />
-                                                    <rect x="3" y="11" width="26" height="2.5" fill="#6b7280" />
-                                                </svg>
-                                            ),
-                                        },
-                                    ] as { key: PayMethod; label: string; icon: ReactNode }[]
-                                ).map((m) => (
-                                    <button
-                                        key={m.key}
-                                        onClick={() => setPayMethod(m.key)}
-                                        className={`flex items-center gap-3 rounded-xl border px-4 py-3 text-left transition-colors ${
-                                            payMethod === m.key ? 'border-[#d4af37] bg-[#d4af37]/5' : 'border-[#2a2a2e] hover:border-[#d4af37]/40'
-                                        }`}
-                                    >
-                                        {/* Radio */}
-                                        <div
-                                            className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 ${
-                                                payMethod === m.key ? 'border-[#d4af37]' : 'border-[#3a3a3e]'
-                                            }`}
-                                        >
-                                            {payMethod === m.key && <div className="h-2.5 w-2.5 rounded-full bg-[#d4af37]" />}
-                                        </div>
-                                        {/* Icon */}
-                                        <div className="flex w-10 shrink-0 items-center justify-center">{m.icon}</div>
-                                        <span className="text-sm font-medium">{m.label}</span>
-                                    </button>
-                                ))}
-                            </div>
+                            <p className="text-xs text-muted-foreground">You can choose your preferred payment channel on the next secure payment page.</p>
                         </div>
 
                         {/* Footer */}
@@ -1014,8 +1056,8 @@ export default function CustomerServices() {
                                     Back
                                 </button>
                                 <button
-                                    onClick={submitBooking}
-                                    disabled={isSubmitting || !payMethod}
+                                    onClick={submitBookingWithPayment}
+                                    disabled={isSubmitting}
                                     className="flex items-center gap-2 rounded-lg bg-[#d4af37] px-5 py-2 text-sm font-bold text-black shadow-[0_4px_12px_rgba(212,175,55,0.3)] transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
                                 >
                                     {isSubmitting && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
@@ -1065,7 +1107,7 @@ export default function CustomerServices() {
                                     </span>
                                 </div>
                                 <p className="mb-4 text-sm font-semibold">
-                                    {selectedDate.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}, {slot.time}
+                                    {selectedDate.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}, {slotLabel}
                                 </p>
                                 <div className="grid grid-cols-2 gap-3 border-t border-[#2a2a2e] pt-3">
                                     <div>
@@ -1279,7 +1321,7 @@ export default function CustomerServices() {
                                     </span>
                                 </div>
                                 <p className="mb-4 text-sm font-semibold">
-                                    {selectedDate.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}, {slot.time}
+                                    {selectedDate.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}, {slotLabel}
                                 </p>
                                 <div className="grid grid-cols-2 gap-3 border-t border-[#2a2a2e] pt-3">
                                     <div>

--- a/frontend/src/services/customerService.ts
+++ b/frontend/src/services/customerService.ts
@@ -3,7 +3,7 @@
  * Handles customer-facing API calls (billing, logs, vehicles, job orders)
  */
 
-import { CustomerProfile, CustomerTransaction, JobOrder, Vehicle } from '@/types/customer';
+import { BookingAvailability, CustomerProfile, CustomerTransaction, JobOrder, Vehicle } from '@/types/customer';
 import { api, ApiResponse, PaginatedResponse } from './api';
 
 export interface CustomerTransactionFilters {
@@ -40,6 +40,20 @@ export interface CreateBookingData {
     arrival_date: string; // Y-m-d
     arrival_time: string; // HH:MM
     notes?: string;
+}
+
+export type BookingPayMethod = 'gcash' | 'maya' | 'card' | 'bank';
+
+export interface CreateBookingWithPaymentData extends CreateBookingData {
+    payment_method: BookingPayMethod;
+}
+
+export interface CreateBookingWithPaymentResponse {
+    job_order: JobOrder;
+    transaction_id: number;
+    reservation_fee_amount: number;
+    payment_url: string;
+    payment_method: BookingPayMethod;
 }
 
 class CustomerService {
@@ -86,6 +100,16 @@ class CustomerService {
 
     async createBooking(data: CreateBookingData): Promise<ApiResponse<JobOrder>> {
         return api.post<ApiResponse<JobOrder>>('/v1/customer/book', data);
+    }
+
+    async createBookingWithPayment(data: CreateBookingWithPaymentData): Promise<ApiResponse<CreateBookingWithPaymentResponse>> {
+        return api.post<ApiResponse<CreateBookingWithPaymentResponse>>('/v1/customer/book-with-payment', data);
+    }
+
+    async getBookingAvailability(arrivalDate: string): Promise<ApiResponse<BookingAvailability>> {
+        return api.get<ApiResponse<BookingAvailability>>('/v1/customer/availability', {
+            arrival_date: arrivalDate,
+        });
     }
 }
 

--- a/frontend/src/types/customer/index.ts
+++ b/frontend/src/types/customer/index.ts
@@ -86,6 +86,20 @@ export interface CartItem {
     quantity: number;
 }
 
+export interface BookingTimeSlot {
+    time: string; // HH:MM
+    label: string; // e.g. 10:00 AM
+    status: 'available' | 'full';
+    slots_left: number;
+    capacity: number;
+    booked: number;
+}
+
+export interface BookingAvailability {
+    arrival_date: string;
+    slots: BookingTimeSlot[];
+}
+
 export type JobOrderStatus = 'created' | 'pending_approval' | 'approved' | 'in_progress' | 'completed' | 'settled' | 'cancelled';
 
 export interface JobOrder {


### PR DESCRIPTION
add booking_slots model, migration, admin API, and gate for managing slot settings add customer availability endpoint and frontend slot loading for service booking add booking-with-payment endpoint that creates a job order, transaction, and Xendit invoice only consume slot capacity after reservation fee payment is marked paid simplify customer payment modal by removing payment-method selection UI add fixed booking reservation fee config and suppress PHP 8.4 Xendit deprecation noise add backend feature tests for booking availability, paid slot locking, and admin slot settings